### PR TITLE
Get basic PICMI input files running

### DIFF
--- a/Source/Initialization/WarpXAMReXInit.H
+++ b/Source/Initialization/WarpXAMReXInit.H
@@ -25,8 +25,8 @@ amrex::AMReX*
 warpx_amrex_init(
     int& argc,
     char**& argv,
-    bool const build_parm_parse = true,
-    MPI_Comm const mpi_comm = MPI_COMM_WORLD
+    bool const build_parm_parse = true
+    /* MPI_Comm const mpi_comm = MPI_COMM_WORLD */
 );
 
 #endif

--- a/Source/Initialization/WarpXAMReXInit.cpp
+++ b/Source/Initialization/WarpXAMReXInit.cpp
@@ -52,13 +52,13 @@ namespace {
 }
 
 amrex::AMReX*
-warpx_amrex_init (int& argc, char**& argv, bool const build_parm_parse, MPI_Comm const mpi_comm)
+warpx_amrex_init (int& argc, char**& argv, bool const build_parm_parse)
 {
     return amrex::Initialize(
         argc,
         argv,
         build_parm_parse,
-        mpi_comm,
+        MPI_COMM_WORLD,
         overwrite_amrex_parser_defaults
     );
 }

--- a/Source/Python/WarpX.cpp
+++ b/Source/Python/WarpX.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2021-2022 The ImpactX Community
+/* Copyright 2021-2022 The WarpX Community
  *
  * Authors: Axel Huebl
  * License: BSD-3-Clause-LBNL
@@ -30,26 +30,33 @@ void init_WarpX (py::module& m)
     warpx
         .def(py::init<>())
 
+        .def("initialize_data", &WarpX::InitData,
+            "Initializes the WarpX simulation"
+        )
+        .def("evolve", &WarpX::Evolve,
+            "Evolve the simulation the specified number of steps"
+        )
+
         // from AmrCore->AmrMesh
         .def("Geom",
-            //[](ImpactX const & ix, int const lev) { return ix.Geom(lev); },
+            //[](WarpX const & wx, int const lev) { return wx.Geom(lev); },
             py::overload_cast< int >(&WarpX::Geom, py::const_),
             py::arg("lev")
         )
         .def("DistributionMap",
-            [](WarpX const & ix, int const lev) { return ix.DistributionMap(lev); },
-            //py::overload_cast< int >(&ImpactX::DistributionMap, py::const_),
+            [](WarpX const & wx, int const lev) { return wx.DistributionMap(lev); },
+            //py::overload_cast< int >(&WarpX::DistributionMap, py::const_),
             py::arg("lev")
         )
         .def("boxArray",
-            [](WarpX const & ix, int const lev) { return ix.boxArray(lev); },
-            //py::overload_cast< int >(&ImpactX::boxArray, py::const_),
+            [](WarpX const & wx, int const lev) { return wx.boxArray(lev); },
+            //py::overload_cast< int >(&WarpX::boxArray, py::const_),
             py::arg("lev")
         )
         .def("multifab",
-            [](WarpX const & ix, std::string const multifab_name) {
-                if (ix.multifab_map.count(multifab_name) > 0) {
-                    return ix.multifab_map.at(multifab_name);
+            [](WarpX const & wx, std::string const multifab_name) {
+                if (wx.multifab_map.count(multifab_name) > 0) {
+                    return wx.multifab_map.at(multifab_name);
                 } else {
                     throw std::runtime_error("The MultiFab '" + multifab_name + "' is unknown or is not allocated!");
                 }

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -154,7 +154,7 @@ namespace
 
     void amrex_init_with_inited_mpi (int argc, char* argv[], MPI_Comm mpicomm)
     {
-        warpx_amrex_init(argc, argv, true, mpicomm);
+        warpx_amrex_init(argc, argv, true);
     }
 
     void amrex_finalize (int /*finalize_mpi*/)

--- a/Source/Python/pyWarpX.cpp
+++ b/Source/Python/pyWarpX.cpp
@@ -6,6 +6,8 @@
 #include "pyWarpX.H"
 
 #include <WarpX.H>
+#include "Initialization/WarpXAMReXInit.H"
+#include "Utils/WarpXUtil.H"
 
 #define STRINGIFY(x) #x
 #define MACRO_STRINGIFY(x) STRINGIFY(x)
@@ -70,7 +72,42 @@ PYBIND11_MODULE(PYWARPX_MODULE_NAME, m) {
     // auto npversion = numpy.attr("__version__");
     // std::cout << "numpy version: " << py::str(npversion) << std::endl;
 
+    m.def("amrex_init",
+        [](const py::list args) {
+            amrex::Vector<std::string> cargs;
+            amrex::Vector<char*> argv;
+
+            // Populate the "command line"
+            for (const auto& v: args)
+                cargs.push_back(v.cast<std::string>());
+            for (auto& v: cargs)
+                argv.push_back(&v[0]);
+            int argc = argv.size();
+
+            // note: +1 since there is an extra char-string array element,
+            //       that ANSII C requires to be a simple NULL entry
+            //       https://stackoverflow.com/a/39096006/2719194
+            argv.push_back(NULL);
+            char** tmp = argv.data();
+
+            const bool build_parm_parse = (cargs.size() > 1);
+            // TODO: handle version with MPI
+            return warpx_amrex_init(argc, tmp, build_parm_parse);
+        }, py::return_value_policy::reference,
+        "Initialize AMReX library");
+    m.def("amrex_finalize", [] () {amrex::Finalize();},
+        "Close out the amrex related data");
+    m.def("warpx_finalize", &WarpX::ResetInstance,
+        "Close out the WarpX related data");
+    m.def("convert_lab_params_to_boost",  &ConvertLabParamsToBoost,
+        "Convert input parameters from the lab frame to the boosted frame");
+    m.def("read_BC_params", &ReadBCParams,
+        "Read the boundary condition parametes and check for consistency");
+    m.def("check_gridding_for_RZ_spectral", &CheckGriddingForRZSpectral,
+        "Ensure that the grid is setup appropriately with using the RZ spectral solver");
+
     // Expose the python callback function installation and removal functions
     m.def("add_python_callback", &InstallPythonCallback);
     m.def("remove_python_callback", &ClearPythonCallback);
+    m.def("execute_python_callback", &ExecutePythonCallback, py::arg("name"));
 }


### PR DESCRIPTION
With these changes, the file `Examples/Tests/langmuir/PICMI_inputs_langmuir_rt.py` now runs to completion.

There are two issues that will need to be dealt with.

1. The original `warpx_amrex_init` allowed passing in an MPI communicator. I couldn't get this to work - I couldn't get the mpi included properly for the pyWarpX.cpp to compile.
2. The call to `warpx_finalize` is causing a crash, something about a null pointer being deallocated. For now, this is commented out. I remember that this was an issue in the past in the original version, but don't remember the solution.

Much work still needs to be done converting the rest of the existing routines to the new method.