### PR TITLE
Fix test Python_pass_mpi_comm

### DIFF
--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -201,7 +201,7 @@ class LibWarpX():
             ctypes.c_char_p(species_name.encode('utf-8')))
 
     def amrex_init(self, argv, mpi_comm=None):
-        if mpi_comm is None or MPI is None:
+        if mpi_comm is None:
             self.libwarpx_so.amrex_init(argv)
         else:
             raise Exception('mpi_comm argument not yet supported')


### PR DESCRIPTION
This test is currently failing because we removed the MPI import, in the `topic-pyAMReX`:
```
  File "/tmp/ci/py-venv/lib/python3.8/site-packages/pywarpx/_libwarpx.py", line 204, in amrex_init
    if mpi_comm is None or MPI is None:
NameError: name 'MPI' is not defined
```